### PR TITLE
Automate intro text translation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 ttkbootstrap
 requests
 Pillow
+deep-translator


### PR DESCRIPTION
## Summary
- streamline the intro configuration UI to a single text field that will be translated automatically based on the video language
- integrate automatic translation for intro texts in the processing pipeline using deep-translator
- surface translation status in render logs and adjust dependency list for the new translator

## Testing
- python -m compileall video_processing_logic.py video_editor_gui.py

------
https://chatgpt.com/codex/tasks/task_e_68dbeb1a0168832097ab387cb332772a