### PR TITLE
Handle optional video_processing_logic import

### DIFF
--- a/gui/app.py
+++ b/gui/app.py
@@ -33,6 +33,11 @@ from ttkbootstrap.constants import *
 from ttkbootstrap.dialogs import Messagebox
 from ttkbootstrap.tooltip import ToolTip
 
+try:
+    import video_processing_logic  # type: ignore
+except ImportError:  # pragma: no cover - fallback assignment
+    video_processing_logic = None  # type: ignore[assignment]
+
 from .config_manager import ConfigManager
 from .constants import (
     APP_DATA_PATH,


### PR DESCRIPTION
## Summary
- fall back to a no-op placeholder when `video_processing_logic` cannot be imported
- keep the processing controller guard that blocks execution when the module is missing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc838ac7f08320904e84c90184ac63