### PR TITLE
Fix hierarchical batch mode video tab display

### DIFF
--- a/gui/app.py
+++ b/gui/app.py
@@ -966,7 +966,7 @@ class VideoEditorApp:
         if is_single_video or is_slideshow:
             self.media_path_label_widget.winfo_children()[0].config(text="Pasta de Imagens:" if is_slideshow else "Ficheiro de Vídeo:")
         self.notebook.tab(1, text="Editor: Vídeo & Slideshow" if is_any_slideshow else "Editor: Vídeo")
-        if is_batch_image or is_batch_hierarchical or is_batch_mixed: self.video_settings_section.grid_remove()
+        if is_batch_image or is_batch_mixed: self.video_settings_section.grid_remove()
         else: self.video_settings_section.grid()
 
     def select_media_single(self):

--- a/tests/test_video_editor_app.py
+++ b/tests/test_video_editor_app.py
@@ -61,3 +61,11 @@ def test_update_ui_for_media_type(app):
     assert not _visible(app.single_inputs_frame)
     assert _visible(app.batch_inputs_frame)
     assert not _visible(app.slideshow_section)
+
+    app.media_type.set("batch_image_hierarchical")
+    app.update_ui_for_media_type()
+    app.root.update()
+    assert _visible(app.batch_inputs_frame)
+    assert _visible(app.batch_hierarchical_inputs_frame)
+    assert _visible(app.video_settings_section)
+    assert not _visible(app.slideshow_section)


### PR DESCRIPTION
## Summary
- keep the video settings section visible when the hierarchical batch mode is selected so the tab is not empty
- extend the GUI update test to cover the hierarchical batch mode layout

## Testing
- pytest tests/test_video_editor_app.py *(fails: Xvfb is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc8b16fbe88320a7fb5bf9ecf15858