### PR TITLE
Implement periodic license revalidation with network backoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Para iniciar a interface gráfica, basta executar:
 python main.py
 ```
 
+## Monitoramento da licença
+
+Depois de validada, a aplicação continua a verificar periodicamente o status da licença junto ao Keygen utilizando o identificador salvo no ficheiro `license.json`. Em caso de falha de rede temporária, o processo regista o erro nos logs e aguarda um intervalo crescente (exponencial) antes de repetir a verificação, evitando encerramentos acidentais. Caso o servidor informe que a licença expirou ou se tornou inválida, o utilizador é avisado e o programa termina imediatamente para impedir o uso não autorizado.
+
 ## Organização das abas do editor
 
 - **Editor: Vídeo** – ajuste a resolução, codec, comportamento do slideshow e configure o encerramento (fade out) que escurece a imagem enquanto reduz o áudio.

--- a/tests/test_license_monitoring.py
+++ b/tests/test_license_monitoring.py
@@ -1,0 +1,108 @@
+import pytest
+
+import license_checker
+from gui.app import VideoEditorApp
+from ttkbootstrap.dialogs import Messagebox
+
+
+class DummyRoot:
+    def __init__(self):
+        self.after_calls = []
+        self.destroyed = False
+
+    def after(self, delay, callback=None, *args):
+        self.after_calls.append((delay, callback, args))
+        return f"job-{len(self.after_calls)}"
+
+    def after_cancel(self, job_id):
+        self.after_calls.append(("cancel", job_id))
+
+    def destroy(self):
+        self.destroyed = True
+
+    def winfo_exists(self):  # pragma: no cover - defensive
+        return not self.destroyed
+
+
+@pytest.fixture
+def license_app(monkeypatch):
+    monkeypatch.setattr(license_checker, "get_machine_fingerprint", lambda: "fingerprint")
+
+    app = VideoEditorApp.__new__(VideoEditorApp)
+    root = DummyRoot()
+    app.root = root
+    app._license_id = "test-id"
+    app._license_fingerprint = "fingerprint"
+    app._license_check_job = None
+    app._license_check_failures = 0
+    app._license_termination_initiated = False
+
+    yield app, root.after_calls
+
+
+def test_periodic_license_validation_success(monkeypatch, license_app):
+    app, after_calls = license_app
+
+    def fake_validate(license_id, fingerprint):
+        assert license_id == "test-id"
+        assert fingerprint == "fingerprint"
+        return {"meta": {"valid": True}}
+
+    monkeypatch.setattr(license_checker, "validate_license_with_id", fake_validate)
+
+    app._run_license_check()
+
+    assert app._license_check_failures == 0
+    assert after_calls
+    assert after_calls[-1][0] == app.LICENSE_CHECK_INTERVAL_MS
+
+
+def test_license_validation_network_backoff(monkeypatch, license_app):
+    app, after_calls = license_app
+    after_calls.clear()
+
+    monkeypatch.setattr(license_checker, "validate_license_with_id", lambda *args, **kwargs: None)
+
+    app._run_license_check()
+
+    assert app._license_check_failures == 1
+    assert after_calls
+    expected_delay = min(
+        app.LICENSE_CHECK_INTERVAL_MS * (2 ** app._license_check_failures),
+        app.LICENSE_CHECK_MAX_INTERVAL_MS,
+    )
+    assert after_calls[-1][0] == expected_delay
+
+
+def test_license_validation_invalid_triggers_exit(monkeypatch, license_app):
+    app, after_calls = license_app
+    after_calls.clear()
+
+    monkeypatch.setattr(
+        license_checker,
+        "validate_license_with_id",
+        lambda *args, **kwargs: {"meta": {"valid": False, "detail": "Expirada"}},
+    )
+
+    warnings = {}
+
+    def fake_warning(message, title, parent=None):
+        warnings["message"] = message
+        warnings["title"] = title
+
+    monkeypatch.setattr(Messagebox, "show_warning", fake_warning)
+
+    destroyed = {"called": False}
+
+    def fake_destroy():
+        destroyed["called"] = True
+
+    app.root.destroy = fake_destroy
+
+    with pytest.raises(SystemExit) as exc:
+        app._run_license_check()
+
+    assert exc.value.code == 1
+    assert warnings["message"] == "Expirada"
+    assert warnings["title"] == "Licença inválida"
+    assert destroyed["called"] is True


### PR DESCRIPTION
## Summary
- add scheduled license validation with exponential backoff handling and immediate shutdown on invalid responses
- document the new background monitoring behaviour in the README
- add unit tests covering success, backoff and invalidation scenarios using simulated Keygen responses

## Testing
- pytest tests/test_license_monitoring.py

------
https://chatgpt.com/codex/tasks/task_e_68dc93a7fa188320953e39b65b796f2d