### PR TITLE
Use native APIs for license fingerprinting

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Depois de validada, a aplicação continua a verificar periodicamente o status d
 
 O token do produto utilizado para contactar a API da Keygen **não** está mais presente no código-fonte. Durante o build (ou execução em desenvolvimento), defina a variável de ambiente `KEYGEN_PRODUCT_TOKEN` ou forneça um caminho através de `KEYGEN_PRODUCT_TOKEN_FILE` apontando para um ficheiro seguro contendo o token. Os pipelines de CI/CD devem injectar esse segredo antes de executar os testes ou distribuir os binários.
 
-O ficheiro `license.json` armazenado no diretório de dados da aplicação é agora cifrado com AES-GCM usando uma chave derivada do _fingerprint_ da máquina. Cada payload inclui um _hash_ autenticado; qualquer tentativa de adulteração resulta na eliminação do ficheiro e na necessidade de reativação manual da licença.
+O ficheiro `license.json` armazenado no diretório de dados da aplicação é agora cifrado com AES-GCM usando uma chave derivada do _fingerprint_ da máquina. Esse identificador é obtido preferencialmente através de APIs nativas do Windows (MachineGuid, SMBIOS ou número de série do volume) e apenas recorre a dados multiplataforma (`uuid.getnode` e `platform.uname`) como último recurso, eliminando dependências de comandos externos. Cada payload inclui um _hash_ autenticado; qualquer tentativa de adulteração resulta na eliminação do ficheiro e na necessidade de reativação manual da licença.
 
 ## Organização das abas do editor
 

--- a/tests/test_machine_fingerprint.py
+++ b/tests/test_machine_fingerprint.py
@@ -1,0 +1,112 @@
+import hashlib
+import license_checker
+
+
+class _FailFallback(Exception):
+    """Erro auxiliar usado quando a estratégia errada é invocada."""
+
+
+def _hash(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def test_get_machine_fingerprint_uses_machine_guid_first(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(license_checker.platform, "system", lambda: "Windows")
+
+    def machine_guid():
+        calls.append("guid")
+        return "GUID-A"
+
+    def firmware():  # pragma: no cover - não deve ser chamado neste cenário
+        raise _FailFallback("Firmware não deveria ser usado")
+
+    def volume():  # pragma: no cover - não deve ser chamado neste cenário
+        raise _FailFallback("Volume não deveria ser usado")
+
+    monkeypatch.setattr(license_checker, "_get_windows_machine_guid", machine_guid)
+    monkeypatch.setattr(license_checker, "_get_windows_firmware_uuid", firmware)
+    monkeypatch.setattr(license_checker, "_get_windows_volume_serial", volume)
+    monkeypatch.setattr(
+        license_checker,
+        "_get_portable_fingerprint_source",
+        lambda: (_ for _ in ()).throw(_FailFallback("Fallback não deveria ser usado")),
+    )
+
+    assert license_checker.get_machine_fingerprint() == _hash("GUID-A")
+    assert calls == ["guid"]
+
+
+def test_get_machine_fingerprint_falls_back_to_firmware_uuid(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(license_checker.platform, "system", lambda: "Windows")
+
+    def machine_guid():
+        calls.append("guid")
+        return None
+
+    def firmware():
+        calls.append("firmware")
+        return "SMBIOS-UUID"
+
+    def volume():  # pragma: no cover - não deve ser chamado neste cenário
+        raise _FailFallback("Volume não deveria ser usado")
+
+    monkeypatch.setattr(license_checker, "_get_windows_machine_guid", machine_guid)
+    monkeypatch.setattr(license_checker, "_get_windows_firmware_uuid", firmware)
+    monkeypatch.setattr(license_checker, "_get_windows_volume_serial", volume)
+    monkeypatch.setattr(
+        license_checker,
+        "_get_portable_fingerprint_source",
+        lambda: (_ for _ in ()).throw(_FailFallback("Fallback não deveria ser usado")),
+    )
+
+    assert license_checker.get_machine_fingerprint() == _hash("SMBIOS-UUID")
+    assert calls == ["guid", "firmware"]
+
+
+def test_get_machine_fingerprint_falls_back_to_volume_serial(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(license_checker.platform, "system", lambda: "Windows")
+
+    def machine_guid():
+        calls.append("guid")
+        return None
+
+    def firmware():
+        calls.append("firmware")
+        return None
+
+    def volume():
+        calls.append("volume")
+        return "1234ABCD"
+
+    monkeypatch.setattr(license_checker, "_get_windows_machine_guid", machine_guid)
+    monkeypatch.setattr(license_checker, "_get_windows_firmware_uuid", firmware)
+    monkeypatch.setattr(license_checker, "_get_windows_volume_serial", volume)
+    monkeypatch.setattr(
+        license_checker,
+        "_get_portable_fingerprint_source",
+        lambda: (_ for _ in ()).throw(_FailFallback("Fallback não deveria ser usado")),
+    )
+
+    assert license_checker.get_machine_fingerprint() == _hash("1234ABCD")
+    assert calls == ["guid", "firmware", "volume"]
+
+
+def test_get_machine_fingerprint_uses_portable_when_not_windows(monkeypatch):
+    monkeypatch.setattr(license_checker.platform, "system", lambda: "Linux")
+
+    def portable():
+        return "portable-id"
+
+    monkeypatch.setattr(
+        license_checker,
+        "_get_portable_fingerprint_source",
+        portable,
+    )
+
+    assert license_checker.get_machine_fingerprint() == _hash("portable-id")


### PR DESCRIPTION
## Summary
- replace the WMIC-based fingerprint with native Windows strategies and a portable fallback
- log which identifier source is chosen and document the new approach in the README
- add unit tests covering each fingerprint branch via monkeypatched strategies

## Testing
- pytest tests/test_machine_fingerprint.py
- pytest *(fails: requires Xvfb for GUI tests in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc9dfc0114832094a989ded6732445