### PR TITLE
Update runtime guard manifest for license checker

### DIFF
--- a/security/runtime_guard.py
+++ b/security/runtime_guard.py
@@ -21,8 +21,8 @@ MANIFEST: Dict[str, object] = {
     "resources": {
         "license_checker.py": {
             "path": "license_checker.py",
-            "hash": "95c60376540cadcdc57b51fed6a693004db967ace488a9d69a331305b8010e26",
-            "signature": "5e42646b65b60373404369360879dc7fc7f4daf2184237f047d041eadee8870e",
+            "hash": "d8731aa591ebf4b432ba39de16da43e56174e5eb4128c1c3edda51d5d2408be1",
+            "signature": "840e578f25e420fc0e40cd711a1a449089834f13443fb68b15bda32308c9e427",
         },
         "video_processing_logic.py": {
             "path": "video_processing_logic.py",


### PR DESCRIPTION
## Summary
- update the runtime guard manifest with the recalculated SHA-256 for license_checker.py
- refresh the corresponding HMAC signature to match the new digest

## Testing
- python - <<'PY'
from security.runtime_guard import enforce_runtime_safety

def main():
    enforce_runtime_safety()
    print('Runtime safety enforced without violations')

if __name__ == '__main__':
    main()
PY

------
https://chatgpt.com/codex/tasks/task_e_68dca32d396c832085e35e25c6922527