### PR TITLE
Update product token loading test for sanitized placeholders

### DIFF
--- a/tests/test_product_token_loading.py
+++ b/tests/test_product_token_loading.py
@@ -1,16 +1,25 @@
 import license_checker
 
 
-def test_get_product_token_from_embedded_resource(monkeypatch):
+def test_get_product_token_from_embedded_resource(monkeypatch, tmp_path):
     monkeypatch.delenv(license_checker.PRODUCT_TOKEN_ENV_VAR, raising=False)
     monkeypatch.delenv(license_checker.PRODUCT_TOKEN_FILE_ENV_VAR, raising=False)
     license_checker.get_product_token.cache_clear()
 
-    token = license_checker.get_product_token()
+    resource_token_path = tmp_path / "product_token.dat"
+    expected = "VALID_TEST_TOKEN"
+    resource_token_path.write_text(expected, encoding="utf-8")
 
-    resource_path = license_checker.resource_path(license_checker.PRODUCT_TOKEN_RESOURCE)
-    with open(resource_path, "r", encoding="utf-8") as resource_file:
-        expected = resource_file.read().strip()
+    original_resource_path = license_checker.resource_path
+
+    def fake_resource_path(relative_path):
+        if relative_path == license_checker.PRODUCT_TOKEN_RESOURCE:
+            return str(resource_token_path)
+        return original_resource_path(relative_path)
+
+    monkeypatch.setattr(license_checker, "resource_path", fake_resource_path)
+
+    token = license_checker.get_product_token()
 
     assert token == expected
 


### PR DESCRIPTION
## Summary
- adjust the product token loading test to use a temporary embedded resource token
- monkeypatch the resource loader to provide a non-placeholder value before calling `get_product_token`

## Testing
- pytest tests/test_product_token_loading.py

------
https://chatgpt.com/codex/tasks/task_e_68dcb39701748320ae37909f8dafa7e8