### PR TITLE
Refactor runtime guard signing to use external key

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Durante o desenvolvimento, as verificações de integridade do `security.runtime
 ficam desativadas para permitir ajustes livres no código-fonte. A validação de hashes
 dos recursos é aplicada apenas nos executáveis empacotados (por exemplo, builds
 gerados com PyInstaller), garantindo que distribuições oficiais mantenham os ficheiros
-críticos intactos.
+críticos intactos. O processo de geração da chave de assinatura e a rotação das
+assinaturas do manifesto estão documentados em [`docs/runtime_guard_key_rotation.md`](docs/runtime_guard_key_rotation.md).
 
 ## Monitoramento da licença
 

--- a/docs/runtime_guard_key_rotation.md
+++ b/docs/runtime_guard_key_rotation.md
@@ -1,0 +1,69 @@
+# Runtime Guard – Rotação de Chave e Reassinatura do Manifesto
+
+Este documento descreve como gerar uma nova chave de assinatura do manifesto,
+armazená-la com segurança e reprocessar as assinaturas utilizadas pelo
+`security/runtime_guard.py`.
+
+## Visão Geral
+
+1. **Gere uma nova chave HMAC** durante o processo de build (idealmente na
+   pipeline de CI) e armazene-a como segredo da plataforma ou artefato seguro.
+2. **Atualize a variável de ambiente `RUNTIME_GUARD_HMAC_KEY`** na etapa de
+   build, fornecendo a chave codificada em Base64.
+3. **Execute o script `tools/sign_runtime_manifest.py`** para recalcular os
+   hashes dos artefatos monitorados e gerar as novas assinaturas.
+4. **Distribua somente os artefatos assinados e a versão atualizada do
+   `runtime_manifest.json`**. A chave secreta nunca deve ser incluída no
+   repositório ou nos pacotes distribuídos.
+
+## Gerando uma nova chave
+
+```
+openssl rand -base64 48 > runtime_guard_hmac.key
+```
+
+Armazene o conteúdo desse arquivo como segredo na infraestrutura de CI/CD.
+
+## Reassinando o manifesto
+
+Na etapa de build (após gerar os binários), execute:
+
+```
+export RUNTIME_GUARD_HMAC_KEY="$(cat runtime_guard_hmac.key)"
+python tools/sign_runtime_manifest.py --base-dir . --executable default=dist/app.exe
+```
+
+Substitua `dist/app.exe` pelo caminho real do executável empacotado gerado pelo
+PyInstaller ou ferramenta equivalente. Caso existam entradas adicionais para
+executáveis, repita o parâmetro `--executable` para cada uma delas.
+
+O script irá:
+
+* recalcular os hashes dos arquivos listados em `security/runtime_manifest.json`;
+* gerar assinaturas HMAC utilizando a chave fornecida; e
+* sobrescrever o arquivo do manifesto com os novos valores.
+
+## Rodando localmente para validação
+
+Em ambientes de desenvolvimento, você pode usar uma chave temporária para
+executar testes automatizados:
+
+```
+export RUNTIME_GUARD_HMAC_KEY="$(openssl rand -base64 32)"
+python tools/sign_runtime_manifest.py
+pytest tests/test_security_runtime_guard.py
+```
+
+Não faça commit da chave temporária – ela serve apenas para validar o fluxo.
+
+## Rotação periódica
+
+1. Gere uma nova chave seguindo o processo descrito acima.
+2. Atualize o segredo correspondente na infraestrutura de CI/CD.
+3. Reexecute o script `sign_runtime_manifest.py` durante o build para produzir
+   novas assinaturas.
+4. Distribua os artefatos resultantes e, se aplicável, atualize o manifesto no
+   repositório.
+
+Se o manifesto for versionado, inclua o arquivo atualizado (`security/runtime_manifest.json`)
+no commit associado à release para manter a auditoria consistente.

--- a/security/runtime_manifest.json
+++ b/security/runtime_manifest.json
@@ -1,0 +1,23 @@
+{
+    "algorithm": "sha256",
+    "executables": {
+        "default": {
+            "hash": "b859e40bc51661cfb179a10749fddf146f352fe6c9ee3acb370ddc12bc6900ce",
+            "signature": "342024f7712fa9a34377e1e4eb62d911b8cac2933d8cdc70d8e634505322a68a"
+        }
+    },
+    "resources": {
+        "license_checker.py": {
+            "hash": "93787fdb53c6a665fef32e901aea948d1493995afc40db369d8aee79daafd2bd",
+            "normalize_newlines": true,
+            "path": "license_checker.py",
+            "signature": "158289e66b06fcbfb8c7d2a4e69086d6a8ecc262f2171ebbc27f95c56201457a"
+        },
+        "video_processing_logic.py": {
+            "hash": "e5ea0942d43c4f9f0bbc3164e1439e5306ac34e88fa6e91a49eeaadce83ccbfb",
+            "normalize_newlines": true,
+            "path": "video_processing_logic.py",
+            "signature": "394687323ce0ab8b2cc7056c3cf4e217845771cd0cbdb55499c3dd54dbd332ae"
+        }
+    }
+}

--- a/tools/sign_runtime_manifest.py
+++ b/tools/sign_runtime_manifest.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Assina o manifesto de segurança utilizando uma chave HMAC externa.
+
+Este script é destinado ao pipeline de build e não deve ser executado em
+ambientes onde a chave não esteja protegida. A chave pode ser fornecida via
+variável de ambiente ``RUNTIME_GUARD_HMAC_KEY`` (codificada em Base64) ou por
+arquivo.
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import binascii
+import json
+import os
+from pathlib import Path
+from typing import Dict, Tuple
+
+import hashlib
+import hmac
+
+ENV_VAR_NAME = "RUNTIME_GUARD_HMAC_KEY"
+
+
+def _decode_key(raw_key: str) -> bytes:
+    try:
+        key = base64.b64decode(raw_key, validate=True)
+    except (binascii.Error, ValueError) as exc:  # pragma: no cover - validação defensiva
+        raise SystemExit(f"Falha ao decodificar chave HMAC: {exc}") from exc
+    if not key:
+        raise SystemExit("Chave HMAC decodificada é vazia; verifique o segredo informado")
+    return key
+
+
+def load_key(args: argparse.Namespace) -> bytes:
+    if args.key_file:
+        raw = Path(args.key_file).read_text(encoding="utf-8").strip()
+        return _decode_key(raw)
+
+    raw = os.environ.get(ENV_VAR_NAME)
+    if not raw:
+        raise SystemExit(
+            "Chave HMAC não fornecida. Defina RUNTIME_GUARD_HMAC_KEY ou use --key-file."
+        )
+    return _decode_key(raw)
+
+
+def compute_hash(path: Path, algorithm: str, normalize_newlines: bool) -> str:
+    h = hashlib.new(algorithm)
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(65536), b""):
+            if normalize_newlines:
+                chunk = chunk.replace(b"\r\n", b"\n")
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def sign_hash(key: bytes, digest: str) -> str:
+    return hmac.new(key, digest.encode("utf-8"), hashlib.sha256).hexdigest()
+
+
+def parse_executable_args(values: Tuple[str, ...]) -> Dict[str, Path]:
+    mapping: Dict[str, Path] = {}
+    for item in values:
+        if "=" not in item:
+            raise SystemExit("Parâmetros de executável devem seguir o formato nome=caminho")
+        name, path = item.split("=", 1)
+        mapping[name.strip()] = Path(path).expanduser().resolve()
+    return mapping
+
+
+def sign_manifest(args: argparse.Namespace) -> None:
+    key = load_key(args)
+    manifest_path = Path(args.manifest).resolve()
+    base_dir = Path(args.base_dir).resolve()
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    algorithm = manifest.get("algorithm", "sha256")
+    resources = manifest.get("resources", {})
+    executables = manifest.get("executables", {})
+
+    executable_paths = parse_executable_args(tuple(args.executable or ()))
+
+    for name, resource in resources.items():
+        rel_path = resource.get("path")
+        if not rel_path:
+            raise SystemExit(f"Recurso '{name}' não possui caminho definido no manifesto")
+        file_path = (base_dir / rel_path).resolve()
+        if not file_path.exists():
+            raise SystemExit(f"Arquivo de recurso não encontrado: {file_path}")
+        normalize = bool(resource.get("normalize_newlines"))
+        digest = compute_hash(file_path, algorithm, normalize)
+        resource["hash"] = digest
+        resource["signature"] = sign_hash(key, digest)
+
+    for name, entry in executables.items():
+        executable_path = executable_paths.get(name)
+        if executable_path:
+            if not executable_path.exists():
+                raise SystemExit(f"Executável '{name}' não encontrado em {executable_path}")
+            digest = compute_hash(executable_path, algorithm, False)
+            entry["hash"] = digest
+        elif not entry.get("hash"):
+            raise SystemExit(
+                f"Nenhum hash informado para o executável '{name}'. Forneça --executable {name}=caminho."
+            )
+        entry_hash = entry.get("hash")
+        if not entry_hash:
+            raise SystemExit(f"Hash ausente para o executável '{name}'")
+        entry["signature"] = sign_hash(key, entry_hash)
+
+    manifest_path.write_text(json.dumps(manifest, indent=4, sort_keys=True), encoding="utf-8")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Assina o manifesto do runtime guard")
+    parser.add_argument(
+        "--manifest",
+        default="security/runtime_manifest.json",
+        help="Caminho para o manifesto a ser assinado (JSON)",
+    )
+    parser.add_argument(
+        "--base-dir",
+        default=".",
+        help="Diretório base para resolução dos caminhos dos recursos",
+    )
+    parser.add_argument(
+        "--executable",
+        action="append",
+        metavar="NOME=CAMINHO",
+        help="Mapeia uma entrada de executável para o caminho gerado durante o build",
+    )
+    parser.add_argument(
+        "--key-file",
+        help="Arquivo contendo a chave HMAC codificada em Base64 (alternativa à variável de ambiente)",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    sign_manifest(args)
+
+
+if __name__ == "__main__":  # pragma: no cover - execução via CLI
+    main()


### PR DESCRIPTION
## Summary
- load the runtime guard manifest from an external JSON file and require an HMAC key supplied at runtime via environment variable, failing securely when unavailable
- add a build tool to re-sign the manifest with the build-time key and document the rotation and signing workflow for developers
- update runtime guard tests to exercise the new key-loading and failure paths

## Testing
- pytest tests/test_security_runtime_guard.py

------
https://chatgpt.com/codex/tasks/task_e_68dcbe36f13c8320800485c88473e4d4